### PR TITLE
feat: add SectionTitle component

### DIFF
--- a/src/components/ui/SectionTitle/SectionTitle.tsx
+++ b/src/components/ui/SectionTitle/SectionTitle.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+interface SectionTitleProps {
+  heading: string;
+  subheading?: string;
+  className?: string;
+}
+
+export function SectionTitle({ heading, subheading, className = "" }: SectionTitleProps) {
+  return (
+    <div className={`text-center text-[#D9D9D9] flex items-center justify-center flex-col gap-6 ${className}`}>
+      <div className="inline-flex items-center rounded-full px-14 md:py-2 text-2xl md:text-5xl bg-[#03CEA433]">
+        {heading}
+      </div>
+      {subheading && (
+        <p className="text-[15px] md:text-[24px] max-w-72 md:max-w-[1000px] font-light">
+          {subheading}
+        </p>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,2 +1,4 @@
 import { Button } from './Button/Button';
-export {Button}
+import { SectionTitle } from './SectionTitle/SectionTitle';
+
+export { Button, SectionTitle };


### PR DESCRIPTION
## Summary
- add reusable SectionTitle component for blog headings
- export SectionTitle from ui index

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in src/pages/Home/Home.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7d3210648322b9c6f4ec24f2cce6