### PR TITLE
refactor: unify section headings

### DIFF
--- a/src/components/Home/Brands/Brands.tsx
+++ b/src/components/Home/Brands/Brands.tsx
@@ -2,6 +2,7 @@ import brands1_d from "/brands/Brands1_d.svg";
 import brands2_d from "/brands/Brands2_d.svg";
 import brands1_m from "/brands/Brands1_m.svg";
 import brands2_m from "/brands/Brands2_m.svg";
+import { SectionTitle } from "../../ui";
 
 const desktopUrls = [brands1_d, brands2_d];
 const mobileUrls  = [brands1_m, brands2_m];
@@ -9,12 +10,10 @@ const mobileUrls  = [brands1_m, brands2_m];
 export default function Brands() {
   return (
     <section className="w-full py-10 md:py-14 mt-36 font-sans">
-      <div className="px-4 md:px-8">
-        <h2 className="text-center text-[#F1F1F1] text-sm md:text-base">
-          Мы помогли более 100+ компаниям
-        </h2>
-        <div className="mx-auto mt-4 mb-8 h-px w-full max-w-[900px] bg-white" />
-      </div>
+      <SectionTitle
+        heading="Мы помогли более 100+ компаниям"
+        className="px-4 md:px-8 mb-8"
+      />
 
       <div className="hidden sm:block">
         {desktopUrls.map((src, i) => (

--- a/src/components/Home/Carousels/ProjectsCarousel.tsx
+++ b/src/components/Home/Carousels/ProjectsCarousel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Button } from "../../ui";
+import { Button, SectionTitle } from "../../ui";
 import type { Project } from "../../../app/data/Projects";
 import ProjectModal from "../../ui/ProjectModal/ProjectModal";
 
@@ -80,18 +80,7 @@ export default function ProjectsCarousel({
   return (
     <section className={`w-full py-8 md:py-12 ${className}`}>
       <div className="mx-auto max-w-[1280px] px-4 md:px-8">
-        <h2
-          className="
-            mx-auto mb-8 inline-flex items-center justify-center
-            rounded-full px-6 md:px-10 py-2
-            font-mono text-sm md:text-lg text-white/90
-            ring-1 ring-white/10 shadow-[inset_0_-1px_0_rgba(255,255,255,.12)]
-            bg-[linear-gradient(180deg,rgba(15,61,57,.65),rgba(9,34,39,.65))]
-            backdrop-blur-[2px]
-          "
-        >
-          {badgeLabel}
-        </h2>
+        <SectionTitle heading={badgeLabel} className="mb-8" />
 
         <div ref={wrapRef} aria-roledescription="carousel" aria-label="Проекты">
           <div

--- a/src/components/Home/Carousels/ServicesCarousel.tsx
+++ b/src/components/Home/Carousels/ServicesCarousel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import type { EmblaOptionsType } from "embla-carousel";
 import Autoplay from "embla-carousel-autoplay";
-import { Button } from "../../ui";
+import { Button, SectionTitle } from "../../ui";
 
 const slides = [
   {
@@ -57,6 +57,7 @@ export default function ServicesCarousel() {
 
   return (
     <section className="relative w-full font-sans ">
+      <SectionTitle heading="Услуги" className="mb-6" />
       <div className="overflow-hidden rounded-[28px]" ref={emblaRef}>
         <div className="flex">
           {slides.map((s, i) => (

--- a/src/components/Home/ListFeatures/Features.tsx
+++ b/src/components/Home/ListFeatures/Features.tsx
@@ -1,4 +1,5 @@
 import { FaStar, FaCogs, FaWrench, FaPhoneAlt } from "react-icons/fa";
+import { SectionTitle } from "../../ui";
 
 const features = [
   {
@@ -26,6 +27,7 @@ const features = [
 export default function Features() {
   return (
     <section className="w-full bg-gradient-to-r from-teal-200 to-teal-300 py-10 rounded-2xl text-black mt-28 font-sans">
+      <SectionTitle heading="Преимущества" className="text-black mb-10" />
       <div className="max-w-7xl mx-auto px-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-center">
         {features.map((f, i) => (
           <div key={i} className="flex flex-col items-center gap-3">

--- a/src/components/Home/PricingPlans/PricingPlans.tsx
+++ b/src/components/Home/PricingPlans/PricingPlans.tsx
@@ -1,4 +1,4 @@
-import { Button } from "../../ui";
+import { Button, SectionTitle } from "../../ui";
 
 /* ---------- Типы ---------- */
 type Plan = {
@@ -143,7 +143,6 @@ export default function PricingPlans() {
   return (
     <section
       className="relative w-full py-12 sm:py-14 md:py-20 text-center"
-      aria-labelledby="pricing-heading"
     >
       {/* фон за секцией */}
       <div className="pointer-events-none absolute inset-0 -z-10">
@@ -157,18 +156,10 @@ export default function PricingPlans() {
       </div>
 
       <div className="mx-auto max-w-[1200px] px-4 md:px-8 font-mono">
-        <h2
-          id="pricing-heading"
-          className="inline-flex items-center rounded-full px-6 sm:px-10 md:px-14 py-1.5 md:py-2 text-lg sm:text-2xl md:text-5xl bg-[#03CEA433]"
-        >
-          Пакеты наших услуг
-        </h2>
-
-        <p className="mx-auto mt-4 sm:mt-5 max-w-3xl text-[13px] sm:text-base md:text-2xl text-white/90">
-          Изучите наши гибкие тарифные планы, удовлетворяющие потребности любого
-          бизнеса. Выберите план, который соответствует вашему бюджету и
-          требованиям, а мы позаботимся обо всём остальном.
-        </p>
+        <SectionTitle
+          heading="Пакеты наших услуг"
+          subheading="Изучите наши гибкие тарифные планы, удовлетворяющие потребности любого бизнеса. Выберите план, который соответствует вашему бюджету и требованиям, а мы позаботимся обо всём остальном."
+        />
 
         {/* Сетка карточек */}
         <div

--- a/src/components/Home/ProjectPhases/ProjectPhases.tsx
+++ b/src/components/Home/ProjectPhases/ProjectPhases.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { SectionTitle } from "../../ui";
 
 export type Stage = {
   number: number;
@@ -54,9 +55,7 @@ export default function ProjectPhases({
 }: ProjectPhasesProps) {
   return (
     <section className={`relative font-mono  text-white flex flex-col text-center justify-center items-center ${className} `}>
-      <div className="inline-flex items-center rounded-full px-14  md:py-2  text-xl md:text-5xl w-72 md:w-auto bg-[#03CEA433]">
-        {heading}
-      </div>
+      <SectionTitle heading={heading} />
       <div className="absolute inset-0 -z-10" />
 
       <div className="pointer-events-none absolute inset-0 [mask-image:radial-gradient(70%_100%_at_50%_50%,#000_55%,transparent_100%)]">

--- a/src/components/Home/ReadySolutions/ReadySolutions.tsx
+++ b/src/components/Home/ReadySolutions/ReadySolutions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Button } from "../../ui";
+import { Button, SectionTitle } from "../../ui";
 
 type Solution = {
   id: string;
@@ -132,14 +132,11 @@ const ReadySolutions = ({ solutions = DEFAULT_SOLUTIONS }: Props) => {
   return (
     <section className="w-full py-12 md:py-16 font-sans">
       <div className="mx-auto max-w-[1200px] px-4 md:px-8">
-        <div className="flex flex-col justify-center items-center mb-24">
-          <h2 className="rounded-full px-6 md:px-14 py-2 text-xl md:text-5xl bg-[#03CEA433]">
-            Готовые отраслевые решения
-          </h2>
-          <p className="mx-auto mt-5 max-w-3xl text-sm md:text-2xl text-white">
-            Типовые решения для различных сфер бизнеса
-          </p>
-        </div>
+        <SectionTitle
+          heading="Готовые отраслевые решения"
+          subheading="Типовые решения для различных сфер бизнеса"
+          className="mb-24"
+        />
 
         <ul className="mt-8 md:mt-12 space-y-8 flex flex-col gap-14">
           {solutions.map((s) => (

--- a/src/components/Home/Technology/Technology.tsx
+++ b/src/components/Home/Technology/Technology.tsx
@@ -1,5 +1,6 @@
 import brands3_d from "/brands/Brands3_d.svg";
 import brands3_m from "/brands/Brands3_m.svg";
+import { SectionTitle } from "../../ui";
 
 const desktopUrls = [brands3_d];
 const mobileUrls = [brands3_m];
@@ -7,11 +8,10 @@ const mobileUrls = [brands3_m];
 export default function Technology() {
   return (
     <section className="w-full py-10 md:py-14 mt-36 font-sans">
-      <div className="px-4 md:px-8 mb-5">
-        <h2 className="text-center text-white text-sm md:text-2xl">
-          Мы используем новейшее оборудование от:
-        </h2>
-      </div>
+      <SectionTitle
+        heading="Мы используем новейшее оборудование от:"
+        className="px-4 md:px-8 mb-5"
+      />
 
       <div className="hidden sm:block">
         {desktopUrls.map((src, i) => (

--- a/src/components/ui/Slider/Slider.tsx
+++ b/src/components/ui/Slider/Slider.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import type { EmblaOptionsType } from "embla-carousel";
 import Autoplay from "embla-carousel-autoplay";
-import { Button } from "../../ui";
+import { Button, SectionTitle } from "../../ui";
 
 export type Slide = {
   title: string;
@@ -68,15 +68,8 @@ export default function Slider({
 
   return (
     <section className={`relative w-full font-sans p-4 ${className}`}>
-      <div className="mb-12 md:mb-16 text-center text-[#D9D9D9] flex items-center justify-center flex-col gap-6 relative">
-        <div className="inline-flex items-center rounded-full px-14 md:py-2 text-2xl md:text-5xl bg-[#03CEA433]">
-          {heading}
-        </div>
-        {subheading && (
-          <p className="text-[15px] md:text-[24px] max-w-72 md:max-w-[1000px] font-light">
-            {subheading}
-          </p>
-        )}
+      <div className="mb-12 md:mb-16 relative">
+        <SectionTitle heading={heading} subheading={subheading} />
 
         {showGlow && (
           <div


### PR DESCRIPTION
## Summary
- use shared SectionTitle component across home page sections
- refactor slider to render SectionTitle for consistency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b58f6b3368832281181a2101b017c9