### PR TITLE
feat: add contact form component

### DIFF
--- a/src/components/Home/ContactForm/ContactForm.tsx
+++ b/src/components/Home/ContactForm/ContactForm.tsx
@@ -1,0 +1,42 @@
+import { Button } from "../../ui";
+
+export default function ContactForm() {
+  return (
+    <section
+      id="contact"
+      className="py-24 w-full flex items-center justify-center px-4"
+    >
+      <form className="w-full max-w-2xl bg-[#010C15] rounded-2xl p-8 md:p-10 flex flex-col gap-6 text-white shadow-lg">
+        <div className="text-center space-y-4">
+          <h2 className="text-2xl md:text-4xl font-semibold">Связаться с нами</h2>
+          <p className="text-sm md:text-lg text-white/70">
+            Заполните данную форму и мы с радостью предложим решение вашего вопроса
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+          <input
+            type="text"
+            placeholder="Имя"
+            className="w-full rounded-xl bg-[#1F2733] px-4 py-3 md:px-6 md:py-4 placeholder:text-white/50 focus:outline-none"
+          />
+          <input
+            type="email"
+            placeholder="Электронная почта"
+            className="w-full rounded-xl bg-[#1F2733] px-4 py-3 md:px-6 md:py-4 placeholder:text-white/50 focus:outline-none"
+          />
+        </div>
+
+        <textarea
+          placeholder="Что еще вас интересует?"
+          className="w-full min-h-[140px] md:min-h-[180px] rounded-xl bg-[#1F2733] px-4 py-3 md:px-6 md:py-4 placeholder:text-white/50 focus:outline-none resize-none"
+        />
+
+        <div className="pt-2 flex justify-center">
+          <Button size="md">Отправить</Button>
+        </div>
+      </form>
+    </section>
+  );
+}
+

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -16,6 +16,7 @@ import ReadySolutions from "../../components/Home/ReadySolutions/ReadySolutions"
 import ProjectsCarousel from "../../components/Home/Carousels/ProjectsCarousel";
 import {PROJECTS} from "../../app/data/Projects"
 import TransformationCTA from "../../components/Home/TransformationCTA/TransformationCTA";
+import ContactForm from "../../components/Home/ContactForm/ContactForm";
 
 const HEADER_OFFSET = 80;
 
@@ -54,8 +55,9 @@ export default function Home() {
       <HostingSection/>
       <PricingPlans/>
       <SpecialSolutions/>
-      <ReadySolutions/>  
+      <ReadySolutions/>
       <ProjectsCarousel projects={PROJECTS}/>
+      <ContactForm/>
       <TransformationCTA/>
     </main>
   );


### PR DESCRIPTION
## Summary
- add responsive contact form with name, email and message fields
- hook contact form into home page for `#contact` anchor links

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b8c286d08322ac23a24b9394a940