### PR TITLE
feat: add tariffs hero variant

### DIFF
--- a/src/components/Services/ServiceHero/ServiceHero.tsx
+++ b/src/components/Services/ServiceHero/ServiceHero.tsx
@@ -1,7 +1,8 @@
 import { Button } from "../../ui";
 
 type ServiceHeroProps = {
-  svgSrc: string;
+  svgSrc?: string;
+  image?: React.ReactNode;
   title: string;
   subtitle?: string;
   ctaHref?: string;
@@ -10,7 +11,8 @@ type ServiceHeroProps = {
 };
 
 export default function ServiceHero({
-  svgSrc,
+  svgSrc = "",
+  image,
   title,
   subtitle,
   ctaHref = "#contact",
@@ -26,12 +28,14 @@ export default function ServiceHero({
       }}
     >
 
-      <img
-        src={svgSrc}
-        alt=""
-        className="relative z-10 w-full h-auto select-none"
-        loading="eager"
-      />
+      {image ?? (
+        <img
+          src={svgSrc}
+          alt=""
+          className="relative z-10 w-full h-auto select-none"
+          loading="eager"
+        />
+      )}
 
       <div className="relative z-10 mx-auto max-w-5xl text-center mt-12 px-4">
         <h1

--- a/src/components/Tariffs/TariffsHero.tsx
+++ b/src/components/Tariffs/TariffsHero.tsx
@@ -1,0 +1,23 @@
+import ServiceHero from "../Services/ServiceHero/ServiceHero";
+
+const TariffsHero = () => (
+  <ServiceHero
+    image={
+      <picture>
+        <source media="(max-width: 640px)" srcSet="/assets/tariffs-hero-small.svg" />
+        <img
+          src="/assets/tariffs-hero.svg"
+          alt="1C:Enterprise — удалённый доступ"
+          className="relative z-10 w-full h-auto select-none"
+          loading="eager"
+        />
+      </picture>
+    }
+    title={`Безопасный удаленный доступ\nк приложениям 1C:Enterprise`}
+    subtitle={`Наслаждайтесь быстрым и надежным подключением, лёгкой интеграцией\nс существующим программным обеспечением «1C:Enterprise» и\nспокойствием за безопасность ваших данных благодаря принятым\nв отрасли мерам безопасности.`}
+    ctaLabel="Связаться с нами"
+  />
+);
+
+export default TariffsHero;
+export { TariffsHero as ServiceHeroTariffs };

--- a/src/pages/Tariffs/Tariffs.tsx
+++ b/src/pages/Tariffs/Tariffs.tsx
@@ -1,10 +1,18 @@
 
-const Tariffs  = () => {
-  return (
-    <div>
-      OneC
-    </div>
-  )
-}
+import TariffsHero from "../../components/Tariffs/TariffsHero";
 
-export default Tariffs 
+const Tariffs = () => {
+  return (
+    <div
+      className="min-h-screen w-full"
+      style={{
+        background:
+          "linear-gradient(180deg, #010B14 0%, rgba(1, 11, 20, 0) 100%)",
+      }}
+    >
+      <TariffsHero />
+    </div>
+  );
+};
+
+export default Tariffs;


### PR DESCRIPTION
## Summary
- allow ServiceHero to accept custom image markup for responsive assets
- add TariffsHero variant with mobile/desktop images and new texts
- render TariffsHero on tariffs page

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b730c7fae08322b942bbdcf8ac313b