### PR TITLE
chore: unify block spacing and clean code

### DIFF
--- a/src/components/Home/About/About.tsx
+++ b/src/components/Home/About/About.tsx
@@ -5,7 +5,7 @@ export default function About() {
   return (
     <section
       id="about"
-      className="relative py-16 px-6 md:px-20 font-mono text-center overflow-hidden"
+      className="relative py-20 px-6 md:px-20 font-mono text-center overflow-hidden"
     >
 
       <div className="mx-auto relative z-10 text-white">

--- a/src/components/Home/Brands/Brands.tsx
+++ b/src/components/Home/Brands/Brands.tsx
@@ -2,7 +2,7 @@ import { BRANDS_DESKTOP, BRANDS_MOBILE } from "../../../app/data/brands";
 
 export default function Brands() {
   return (
-    <section className="w-full py-10 md:py-14 mt-36 font-sans">
+    <section className="w-full py-20 mt-36 font-sans">
      <div className="px-4 md:px-8">
         <h2 className="text-center text-[#F1F1F1] text-sm md:text-base">
           Мы помогли более 100+ компаниям

--- a/src/components/Home/Carousels/ExpertiseCarousel.tsx
+++ b/src/components/Home/Carousels/ExpertiseCarousel.tsx
@@ -1,4 +1,3 @@
-// components/Home/Expertise/ExpertiseSection.tsx
 import { useCallback, useEffect, useMemo, useState } from "react";
 import useEmblaCarousel from "embla-carousel-react";
 import type { EmblaOptionsType } from "embla-carousel";
@@ -35,9 +34,9 @@ type Props = {
   mobileImageTop?: boolean;
   mobileSlideMinH?: number;
 
-  imageMaxHMobile?: number;   // px
-  imageMaxHDesktop?: number;  // px
-  imageRightPx?: number;      // px
+  imageMaxHMobile?: number;
+  imageMaxHDesktop?: number;
+  imageRightPx?: number;
 
   showArrows?: boolean;
   showDots?: boolean;
@@ -55,7 +54,7 @@ export default function ExpertiseSection({
   glowColor = "#FFEE53",
   glowSize = 200,
   mobileImageTop = true,
-  mobileSlideMinH = 700,           // ⚙️ по умолчанию 900px на мобилке
+  mobileSlideMinH = 700,
   imageMaxHMobile = 300,
   imageMaxHDesktop = 480,
   imageRightPx = 112,
@@ -91,7 +90,6 @@ export default function ExpertiseSection({
 
   return (
     <section className={`relative w-full font-sans p-4 ${className}`}>
-      {/* Заголовки */}
       <div className="mb-12 md:mb-16 relative">
         <SectionTitle heading={heading} subheading={subheading} />
         {showGlow && (
@@ -118,7 +116,7 @@ export default function ExpertiseSection({
             const dMax = s.imgMaxHDesktop ?? imageMaxHDesktop;
             const dRight = s.imgRightPx ?? imageRightPx;
 
-            const hideImage = i === 0; // 🧩 не показываем картинку на первом слайде
+            const hideImage = i === 0;
 
             return (
               <div key={i} className="flex-[0_0_100%]">
@@ -134,7 +132,7 @@ export default function ExpertiseSection({
                     flex flex-col
                   "
                   style={{
-                    ["--mh" as any]: `${mobileSlideMinH}px`,
+                    ["--mh" as string]: `${mobileSlideMinH}px`,
                     background:
                       s.background ??
                       "linear-gradient(280.68deg, #054277 1.65%, #01192A 97.64%)",
@@ -157,7 +155,6 @@ export default function ExpertiseSection({
                     />
                   )}
 
-                  {/* ===== Мобилка: картинка сверху (кроме 1-го слайда) ===== */}
                   {mobileImageTop && s.image && !hideImage && (
                     <div className="md:hidden flex justify-center">
                       <img
@@ -170,7 +167,6 @@ export default function ExpertiseSection({
                     </div>
                   )}
 
-                  {/* Текст на мобилке */}
                   <div className="md:hidden mt-auto font-mono">
                     <h3 className="text-[24px] sm:text-[28px] font-bold leading-snug text-center">
                       {s.title}
@@ -197,7 +193,6 @@ export default function ExpertiseSection({
                     )}
                   </div>
 
-                  {/* ===== Десктоп: текст слева, картинка справа (кроме 1-го) ===== */}
                   <div
                     className="
                       hidden md:grid h-full relative
@@ -205,7 +200,6 @@ export default function ExpertiseSection({
                       items-center
                     "
                   >
-                    {/* Текст — на первом слайде растягиваем на 2 колонки */}
                     <div className={`ml-0 md:ml-28 font-mono ${hideImage ? "md:col-span-2" : ""}`}>
                       <h3 className="text-[32px] lg:text-[40px] font-bold leading-snug">
                         {s.title}
@@ -232,7 +226,6 @@ export default function ExpertiseSection({
                       )}
                     </div>
 
-                    {/* Картинка справа — НЕ рендерим на первом слайде */}
                     {!hideImage && (
                       <div className="h-full">
                         <img
@@ -254,7 +247,6 @@ export default function ExpertiseSection({
                     )}
                   </div>
 
-                  {/* Стрелки */}
                   {showArrows && (
                     <>
                       <button
@@ -289,7 +281,6 @@ export default function ExpertiseSection({
         </div>
       </div>
 
-      {/* Точки */}
       {showDots && (
         <div className="mt-4 hidden md:flex w-full items-center justify-center gap-2">
           {scrollSnaps.map((_, i) => (

--- a/src/components/Home/Carousels/ProjectsCarousel.tsx
+++ b/src/components/Home/Carousels/ProjectsCarousel.tsx
@@ -78,7 +78,7 @@ export default function ProjectsCarousel({
   }, []);
 
   return (
-    <section className={`w-full py-8 md:py-12 ${className}`}>
+    <section className={`w-full py-20 ${className}`}>
       <div className="mx-auto max-w-[1280px] px-4 md:px-8">
         <SectionTitle heading={badgeLabel} className="mb-8" />
 

--- a/src/components/Home/ContactForm/ContactForm.tsx
+++ b/src/components/Home/ContactForm/ContactForm.tsx
@@ -4,7 +4,7 @@ export default function ContactForm() {
   return (
     <section
       id="contact"
-      className="relative bg-transparent py-24 flex items-center justify-center px-4 overflow-hidden px-20"
+      className="relative bg-transparent py-20 flex items-center justify-center overflow-hidden px-20"
     >
       <form className="relative z-10 max-w-2xl w-full bg-[#010C15]/50 backdrop-blur-3xl rounded-2xl border border-white/20 p-8 md:p-10 shadow-lg text-white">
         <div

--- a/src/components/Home/ListFeatures/Features.tsx
+++ b/src/components/Home/ListFeatures/Features.tsx
@@ -2,7 +2,7 @@ import { FEATURES } from "../../../app/data/features";
 
 export default function Features() {
   return (
-    <section className="w-full bg-gradient-to-r from-teal-200 to-teal-300 py-10 rounded-2xl text-black mt-28 font-sans">
+    <section className="w-full bg-gradient-to-r from-teal-200 to-teal-300 py-20 rounded-2xl text-black mt-28 font-sans">
       <div className="max-w-7xl mx-auto px-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 text-center">
         {FEATURES.map((f, i) => (
           <div key={i} className="flex flex-col items-center gap-3">

--- a/src/components/Home/PricingPlans/PricingPlans.tsx
+++ b/src/components/Home/PricingPlans/PricingPlans.tsx
@@ -74,7 +74,7 @@ function PlanCard({ plan }: { plan: Plan }) {
 
 export default function PricingPlans() {
   return (
-    <section className="relative w-full py-10 sm:py-14 md:py-20 text-center">
+    <section className="relative w-full py-20 text-center">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div
           className="absolute left-1/2 top-0 h-48 sm:h-60 md:h-64 w-[820px] sm:w-[1000px] md:w-[1200px] -translate-x-1/2 rounded-full blur-3xl opacity-30"

--- a/src/components/Home/ProjectPhases/ProjectPhases.tsx
+++ b/src/components/Home/ProjectPhases/ProjectPhases.tsx
@@ -13,7 +13,7 @@ export default function ProjectPhases({
   className = "",
 }: ProjectPhasesProps) {
   return (
-    <section className={`relative font-mono  text-white flex flex-col text-center justify-center items-center ${className} `}>
+    <section className={`relative py-20 font-mono text-white flex flex-col text-center justify-center items-center ${className}`}>
       <SectionTitle heading={heading} />
       <div className="absolute inset-0 -z-10" />
 

--- a/src/components/Home/ReadySolutions/ReadySolutions.tsx
+++ b/src/components/Home/ReadySolutions/ReadySolutions.tsx
@@ -80,7 +80,7 @@ const ReadySolutions = ({ solutions = DEFAULT_SOLUTIONS }: Props) => {
   };
 
   return (
-    <section className="w-full py-12 md:py-16 font-sans">
+    <section className="w-full py-20 font-sans">
       <div className="mx-auto max-w-[1200px] px-4 md:px-8">
         <SectionTitle
           heading="Готовые отраслевые решения"

--- a/src/components/Home/Technology/Technology.tsx
+++ b/src/components/Home/Technology/Technology.tsx
@@ -2,7 +2,7 @@ import { TECHNOLOGY_DESKTOP, TECHNOLOGY_MOBILE } from "../../../app/data/technol
 
 export default function Technology() {
   return (
-    <section className="w-full py-10 md:py-14 mt-36 font-sans">
+    <section className="w-full py-20 mt-36 font-sans">
     <div className="px-4 md:px-8 mb-5">
         <h2 className="text-center text-white text-sm md:text-2xl">
           Мы используем новейшее оборудование от:

--- a/src/components/Home/TransformationCTA/TransformationCTA.tsx
+++ b/src/components/Home/TransformationCTA/TransformationCTA.tsx
@@ -2,7 +2,7 @@ import { Button } from "../../ui";
 
 export default function TransformationCTA() {
   return (
-    <section className="w-full py-16 text-center ">
+    <section className="w-full py-20 text-center ">
       <div className="mx-auto max-w-4xl px-4 font-mono">
         <h2 className="text-white text-6xl">Начните цифровую трансформацию сегодня</h2>
 

--- a/src/components/Services/ContactAddressSection/ContactAddressSection.tsx
+++ b/src/components/Services/ContactAddressSection/ContactAddressSection.tsx
@@ -1,4 +1,3 @@
-// components/Contact/ContactAddressSection.tsx
 import { FaBuilding, FaPhoneAlt, FaAt } from "react-icons/fa";
 import type { JSX } from "react";
 import ContactForm from "../../Home/ContactForm/ContactForm";
@@ -7,7 +6,7 @@ type CardProps = {
   title: string;
   lines: (string | JSX.Element)[];
   Icon: React.ElementType;
-  glow: string; // hex
+  glow: string;
 };
 
 function ContactCard({ title, lines, Icon, glow }: CardProps) {
@@ -43,7 +42,7 @@ function ContactCard({ title, lines, Icon, glow }: CardProps) {
 
 export default function ContactAddressSection() {
   return (
-    <section className="relative bg-[#011627] text-white py-16 px-6 md:px-12">
+    <section className="relative bg-[#011627] text-white py-20 px-6 md:px-12">
       <div className="max-w-7xl mx-auto">
         <header className="text-center mb-10 md:mb-14">
           <h2 className="text-2xl md:text-4xl font-semibold">

--- a/src/components/Services/CustomServersSection/CustomServersSection.tsx
+++ b/src/components/Services/CustomServersSection/CustomServersSection.tsx
@@ -1,13 +1,11 @@
-// components/CustomServers/CustomServersSection.tsx
 import { FaServer } from "react-icons/fa";
 import { Button } from "../../ui";
 
 export default function CustomServersSection() {
   return (
-    <section className="relative bg-[#010B14] py-16 px-6 md:px-12 font-mono text-white">
+    <section className="relative bg-[#010B14] py-20 px-6 md:px-12 font-mono text-white">
       <div className="relative z-10 max-w-7xl mx-auto border border-white/10 px-8 md:px-12 bg-[#02111e] backdrop-blur-sm shadow-lg">
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10 items-center">
-          {/* Левая колонка */}
           <div className="space-y-6">
             <FaServer className="text-[#03CEA4] text-3xl" />
             <h2 className="text-2xl md:text-3xl font-semibold">
@@ -22,7 +20,6 @@ export default function CustomServersSection() {
             </p>
           </div>
 
-          {/* Центральная колонка: на всю высоту, фон #02111e */}
           <div
             className="
               col-span-1 md:col-span-1 lg:col-span-1
@@ -37,13 +34,10 @@ export default function CustomServersSection() {
               className="h-full max-h-full w-auto object-contain"
             />
           </div>
-
-          {/* Правая колонка (форма) */}
           <form
             className="flex flex-col gap-4 p-6 shadow-lg h-fit"
             onSubmit={(e) => {
               e.preventDefault();
-              // TODO: Bitrix24 Webhook integration
             }}
           >
             <div>

--- a/src/components/Services/DeploymentComparisonSection/DeploymentComparisonSection.tsx
+++ b/src/components/Services/DeploymentComparisonSection/DeploymentComparisonSection.tsx
@@ -29,7 +29,7 @@ function CellContent({ cell }: { cell: Cell }) {
 export default function DeploymentComparisonSection() {
   return (
     <section
-      className="relative isolate py-16 md:py-20 px-4 md:px-8 font-mono text-white"
+      className="relative isolate py-20 px-4 md:px-8 font-mono text-white"
       aria-label="Сравнение опций развертывания"
     >
       <div className="mx-auto text-center space-y-4 max-w-5xl">
@@ -49,7 +49,6 @@ export default function DeploymentComparisonSection() {
             [background-clip:padding-box]
           "
         >
-          {/* glow */}
           <div
             className="pointer-events-none absolute -top-20 -left-20 h-[360px] w-[520px] rounded-full opacity-[0.25] blur-[140px] transition-opacity duration-300 group-hover:opacity-[0.30]"
             style={{ background: "linear-gradient(135deg, #03CEA4, #4DA3FF)", willChange: "transform" }}
@@ -59,7 +58,6 @@ export default function DeploymentComparisonSection() {
             style={{ background: "linear-gradient(135deg, #C15CFF, #FF6AD5)", willChange: "transform" }}
           />
 
-          {/* Только таблица скроллится по X на узких экранах */}
           <div
             className="relative overflow-x-auto overscroll-contain lg:overflow-x-hidden"
             style={{ WebkitOverflowScrolling: "touch" }}
@@ -76,7 +74,6 @@ export default function DeploymentComparisonSection() {
                 border-separate border-spacing-0
               "
             >
-              {/* фиксированные доли колонок — одинаково в Firefox/Chrome */}
               <colgroup>
                 <col className="w-[30%]" />
                 <col className="w-[35%]" />

--- a/src/components/Services/ProductsSection/ProductsSection.tsx
+++ b/src/components/Services/ProductsSection/ProductsSection.tsx
@@ -1,11 +1,10 @@
-// components/Products/ProductsSection.tsx
 import React from "react";
 
 type ProductCard = {
   title: string;
   text: string;
-  imageSrc: string; // svg/png/jpg из /assets
-  glow: string; // цвет свечения
+  imageSrc: string;
+  glow: string;
 };
 
 type Props = {
@@ -81,9 +80,8 @@ export default function ProductsSection({
   return (
     <section
       id="products"
-      className={`relative w-full py-16 md:py-20 bg-[#010B14] text-white font-mono ${className}`}
+      className={`relative w-full py-20 bg-[#010B14] text-white font-mono ${className}`}
     >
-      {/* Заголовок */}
       <div className="mx-auto max-w-5xl px-4 text-center">
         <h2 className="text-2xl md:text-4xl font-semibold tracking-tight">
           {title}
@@ -93,7 +91,6 @@ export default function ProductsSection({
         </p>
       </div>
 
-      {/* Сетка */}
       <div className="mx-auto mt-10 md:mt-12 max-w-6xl px-4">
         <div className="grid gap-4 sm:gap-6 md:gap-7 grid-cols-1 sm:grid-cols-2 xl:grid-cols-3">
           {items.map((card, i) => (

--- a/src/components/Services/ServerEquipment/ServerEquipment.tsx
+++ b/src/components/Services/ServerEquipment/ServerEquipment.tsx
@@ -37,7 +37,7 @@
 
     export default function ServerEquipment() {
     return (
-        <section className="relative py-20   px-6 md:px-12 lg:px-20 text-white bg-[#010B14]">
+        <section className="relative py-20 px-6 md:px-12 lg:px-20 text-white bg-[#010B14]">
         <div className="text-center mx-auto max-w-2xl">
             <h2 className="text-4xl font-mono font-bold ">
             Что такое серверное оборудование?

--- a/src/components/Services/ServerOptions/ServerOptions.tsx
+++ b/src/components/Services/ServerOptions/ServerOptions.tsx
@@ -1,4 +1,3 @@
-// components/ServerOptions/ServerOptions.tsx
 import { FaCloud } from "react-icons/fa";
 import { FaLocationDot } from "react-icons/fa6";
 import { IoIosCheckmark } from "react-icons/io";
@@ -9,7 +8,7 @@ export default function ServerOptions() {
   return (
     <section
       id="server-options"
-      className="relative py-24 px-6 bg-gradient-to-b from-[#011627] to-[#000b15]"
+      className="relative py-20 px-6 bg-gradient-to-b from-[#011627] to-[#000b15]"
     >
       <div className="max-w-6xl mx-auto text-center space-y-6">
         <h2 className="text-3xl md:text-4xl font-bold text-white">
@@ -22,16 +21,13 @@ export default function ServerOptions() {
         </p>
       </div>
 
-      {/* Сетка карточек */}
       <div className="relative mt-16 grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-        {/* Glow для облачного */}
         <div
           className="absolute -top-24 -left-32 w-[400px] h-[400px] rounded-full opacity-30 blur-[160px] pointer-events-none"
           style={{
             background: "linear-gradient(135deg, #03CEA4 0%, #4DA3FF 100%)",
           }}
         />
-        {/* Glow для локального */}
         <div
           className="absolute -bottom-24 -right-32 w-[400px] h-[400px] rounded-full opacity-30 blur-[160px] pointer-events-none"
           style={{
@@ -39,18 +35,13 @@ export default function ServerOptions() {
               "linear-gradient(135deg, #C15CFF 0%, #FF6AD5 70%, #27AE60 100%)",
           }}
         />
-
-        {/* ---------- Облачное ---------- */}
-        <div className="relative group   border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
-          {/* Header */}
+        <div className="relative group border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
           <div className="flex items-center gap-3 pb-4 mb-6 border-b border-white/10">
             <FaCloud className="text-2xl text-[#03CEA4]" />
             <h3 className="text-xl font-bold text-white">
               Облачное развертывание
             </h3>
           </div>
-
-          {/* Плюсы */}
           <div className="space-y-4 mb-6">
             <h4 className="text-lg font-semibold text-white">Плюсы</h4>
             <ul className="space-y-3 text-white/75">
@@ -85,7 +76,6 @@ export default function ServerOptions() {
             </ul>
           </div>
 
-          {/* Минусы */}
           <div className="space-y-4">
             <h4 className="text-lg font-semibold text-white">Минусы</h4>
             <ul className="space-y-3 text-white/75">
@@ -114,17 +104,13 @@ export default function ServerOptions() {
           </div>
         </div>
 
-        {/* ---------- Локальное ---------- */}
-        <div className="relative group   border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
-          {/* Header */}
+        <div className="relative group border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
           <div className="flex items-center gap-3 pb-4 mb-6 border-b border-white/10">
             <FaLocationDot className="text-2xl text-[#C15CFF]" />
             <h3 className="text-xl font-bold text-white">
               Локальное развертывание
             </h3>
           </div>
-
-          {/* Плюсы */}
           <div className="space-y-4 mb-6">
             <h4 className="text-lg font-semibold text-white">Плюсы</h4>
             <ul className="space-y-3 text-white/75">
@@ -159,7 +145,6 @@ export default function ServerOptions() {
             </ul>
           </div>
 
-          {/* Минусы */}
           <div className="space-y-4">
             <h4 className="text-lg font-semibold text-white">Минусы</h4>
             <ul className="space-y-3 text-white/75">

--- a/src/components/Services/ServersBenefits/ServersBenefits.tsx
+++ b/src/components/Services/ServersBenefits/ServersBenefits.tsx
@@ -1,4 +1,3 @@
-// components/Benefits/ServersBenefits.tsx
 import type { JSX } from "react";
 import {
     FaShieldAlt,
@@ -100,7 +99,6 @@ import {
                   <h3 className="font-semibold text-lg">{b.title}</h3>
                 </div>
   
-                {/* Text */}
                 <p className="text-white/70 ml-9 relative z-10 text-sm leading-relaxed">
                   {b.text}
                 </p>

--- a/src/components/Tariffs/OptionsComparisonSection/OptionsComparisonSection.tsx
+++ b/src/components/Tariffs/OptionsComparisonSection/OptionsComparisonSection.tsx
@@ -1,4 +1,3 @@
-// components/ServerOptions/OptionsComparisonSection.tsx
 import { IoIosCheckmark } from "react-icons/io";
 
 type Cell = { text: string; check?: boolean };
@@ -32,7 +31,7 @@ function CellContent({ cell }: { cell: Cell }) {
 
 export default function OptionsComparisonSection() {
   return (
-    <section className="relative isolate py-16 md:py-20 px-4 md:px-8 font-mono text-white">
+    <section className="relative isolate py-20 px-4 md:px-8 font-mono text-white">
       <div className="mx-auto text-center space-y-4 max-w-5xl">
         <h2 className="text-2xl md:text-4xl font-semibold">Детальное сравнение двух опций</h2>
         <p className="text-white/70 md:text-lg">
@@ -42,7 +41,6 @@ export default function OptionsComparisonSection() {
         </p>
       </div>
 
-      {/* Таблица */}
       <div className="relative mx-auto mt-8 md:mt-12 max-w-6xl">
         <div
           className="
@@ -52,7 +50,6 @@ export default function OptionsComparisonSection() {
             [background-clip:padding-box]
           "
         >
-          {/* Glow */}
           <div
             className="pointer-events-none absolute -top-20 -left-20 h-[360px] w-[520px] rounded-full opacity-[0.25] blur-[140px] transition-opacity duration-300 group-hover:opacity-[0.30]"
             style={{ background: "linear-gradient(135deg, #03CEA4, #4DA3FF)", willChange: "transform" }}
@@ -74,7 +71,6 @@ export default function OptionsComparisonSection() {
                 border-separate border-spacing-0
               "
             >
-              {/* фиксированные доли колонок */}
               <colgroup>
                 <col className="w-[30%]" />
                 <col className="w-[35%]" />

--- a/src/components/Tariffs/Packages/Packages.tsx
+++ b/src/components/Tariffs/Packages/Packages.tsx
@@ -119,7 +119,7 @@ function PlanCard({ plan }: { plan: Plan }) {
 
 export default function Packages() {
   return (
-    <section className="relative w-full py-10 sm:py-14 md:py-20  bg-gradient-to-b from-[#010c15] to-black">
+    <section className="relative w-full py-20 bg-gradient-to-b from-[#010c15] to-black">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute left-1/2 top-0 h-48 sm:h-60 md:h-64 w-[820px] sm:w-[1000px] md:w-[1200px] -translate-x-1/2 rounded-full blur-3xl opacity-30" />
       </div>
@@ -150,7 +150,7 @@ export default function Packages() {
         </div>
       </div>
       <ContactForm />
-      <section className="relative text-white py-16 px-6 md:px-12">
+      <section className="relative text-white py-20 px-6 md:px-12">
         <div className="max-w-7xl mx-auto">
           <header className="text-center mb-10 md:mb-14">
             <h2 className="text-2xl md:text-4xl font-semibold">

--- a/src/components/Tariffs/RdpDeploymentOptions/RdpDeploymentOptions.tsx
+++ b/src/components/Tariffs/RdpDeploymentOptions/RdpDeploymentOptions.tsx
@@ -1,4 +1,3 @@
-// components/ServerOptions/RdpDeploymentOptions.tsx
 import { HiOutlineCloud } from "react-icons/hi";
 import { MdDns } from "react-icons/md";
 import { IoIosCheckmark } from "react-icons/io";
@@ -9,7 +8,7 @@ export default function RdpDeploymentOptions() {
   return (
     <section
       id="rdp-deployment-options"
-      className="relative py-24 px-6 bg-gradient-to-b from-[#011627] to-[#000b15]"
+      className="relative py-20 px-6 bg-gradient-to-b from-[#011627] to-[#000b15]"
     >
       <div className="max-w-6xl mx-auto text-center space-y-6">
         <h2 className="text-3xl md:text-4xl font-bold text-white">
@@ -22,16 +21,13 @@ export default function RdpDeploymentOptions() {
         </p>
       </div>
 
-      {/* Карточки */}
       <div className="relative mt-16 grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-        {/* Glow слева (облако) */}
         <div
           className="absolute -top-24 -left-32 w-[400px] h-[400px] rounded-full opacity-30 blur-[160px] pointer-events-none"
           style={{
             background: "linear-gradient(135deg, #03CEA4 0%, #4DA3FF 100%)",
           }}
         />
-        {/* Glow справа (локально) */}
         <div
           className="absolute -bottom-24 -right-32 w-[400px] h-[400px] rounded-full opacity-30 blur-[160px] pointer-events-none"
           style={{
@@ -39,16 +35,11 @@ export default function RdpDeploymentOptions() {
               "linear-gradient(135deg, #C15CFF 0%, #FF6AD5 70%, #27AE60 100%)",
           }}
         />
-
-        {/* ---------- Облачное ---------- */}
         <div className="relative border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
-          {/* Header */}
           <div className="flex items-center gap-3 pb-4 mb-6 border-b border-white/10">
             <HiOutlineCloud className="text-2xl text-[#03CEA4]" />
             <h3 className="text-xl font-bold text-white">Облачное развертывание</h3>
           </div>
-
-          {/* Плюсы */}
           <div className="space-y-4 mb-6">
             <h4 className="text-lg font-semibold text-white">Плюсы</h4>
             <ul className="space-y-3 text-white/75">
@@ -83,7 +74,6 @@ export default function RdpDeploymentOptions() {
             </ul>
           </div>
 
-          {/* Минусы */}
           <div className="space-y-4">
             <h4 className="text-lg font-semibold text-white">Минусы</h4>
             <ul className="space-y-3 text-white/75">
@@ -112,15 +102,11 @@ export default function RdpDeploymentOptions() {
           </div>
         </div>
 
-        {/* ---------- Локальное ---------- */}
         <div className="relative border border-white/10 bg-white/5 backdrop-blur-md p-8 transition-transform duration-300 hover:-translate-y-1">
-          {/* Header */}
           <div className="flex items-center gap-3 pb-4 mb-6 border-b border-white/10">
             <MdDns className="text-2xl text-[#C15CFF]" />
             <h3 className="text-xl font-bold text-white">Локальное развертывание</h3>
           </div>
-
-          {/* Плюсы */}
           <div className="space-y-4 mb-6">
             <h4 className="text-lg font-semibold text-white">Плюсы</h4>
             <ul className="space-y-3 text-white/75">
@@ -148,7 +134,6 @@ export default function RdpDeploymentOptions() {
             </ul>
           </div>
 
-          {/* Минусы */}
           <div className="space-y-4">
             <h4 className="text-lg font-semibold text-white">Минусы</h4>
             <ul className="space-y-3 text-white/75">

--- a/src/components/Tariffs/SecuritySection/SecuritySection.tsx
+++ b/src/components/Tariffs/SecuritySection/SecuritySection.tsx
@@ -1,4 +1,3 @@
-// components/Security/SecuritySection.tsx
 import type { JSX } from "react";
 import { FaLock, FaUserShield, FaShieldAlt, FaDatabase } from "react-icons/fa";
 import { MdSystemUpdateAlt } from "react-icons/md";

--- a/src/components/Tariffs/TariffsBenefits/TariffsBenefits.tsx
+++ b/src/components/Tariffs/TariffsBenefits/TariffsBenefits.tsx
@@ -1,4 +1,3 @@
-// components/Benefits/TariffsBenefits.tsx
 import type { JSX } from "react";
 import {
   FaLock,

--- a/src/components/Tariffs/TechnicalRequirements/TechnicalRequirements.tsx
+++ b/src/components/Tariffs/TechnicalRequirements/TechnicalRequirements.tsx
@@ -1,4 +1,3 @@
-// components/Requirements/TechnicalRequirements.tsx
 import {
     FaWindows,
     FaChrome,

--- a/src/components/Tariffs/UserBenefits/UserBenefits.tsx
+++ b/src/components/Tariffs/UserBenefits/UserBenefits.tsx
@@ -1,10 +1,5 @@
-// components/Benefits/UserBenefits.tsx
 import type { JSX } from "react";
-import {
-  FaChartLine,      // Эффективность
-  FaUserFriends,    // Коллаборация
-  FaExpandAlt,      // Масштабируемость
-} from "react-icons/fa";
+import { FaChartLine, FaUserFriends, FaExpandAlt } from "react-icons/fa";
 import { MdSecurity, MdDevicesOther, MdPhoneIphone } from "react-icons/md";
 
 type Benefit = {
@@ -61,7 +56,7 @@ const BENEFITS: Benefit[] = [
 
 export default function UserBenefits() {
   return (
-    <section className="py-20 md:pt-44 px-6 text-white">
+    <section className="py-20 px-6 text-white">
       <div className="px-5 md:px-16 mx-auto ">
         <h2 className="text-3xl text-center md:text-4xl font-bold mb-4">
           Преимущества для пользователей
@@ -73,7 +68,6 @@ export default function UserBenefits() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-30">
           {BENEFITS.map((b, i) => (
             <div key={b.title} className="relative flex flex-col items-start gap-3">
-              {/* glow за иконкой */}
               <div
                 className="absolute w-32 h-32 rounded-full blur-[100px] opacity-60 transition-all duration-300"
                 style={{

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,7 +10,7 @@ const year = new Date().getFullYear();
 export default function Footer() {
   return (
     <footer className="border-t border-white/10 text-white/90 font-sans bg-black">
-      <div className="mx-auto px-4 sm:px-8 lg:px-16 py-12 lg:py-16  ">
+      <div className="mx-auto px-4 sm:px-8 lg:px-16 py-20  ">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-10 lg:gap-16">
           <div className="flex flex-col justify-between">
             <div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -51,7 +51,6 @@ export default function Header() {
     setOpen(false);
   };
 
-  // Автоскролл при переходе на главную с хэшемx
   useEffect(() => {
     if (isHome && location.hash) {
       const id = location.hash.replace("#", "");
@@ -82,8 +81,6 @@ export default function Header() {
         >
           <img src="/logo.svg" alt="ITSource Logo" className="h-9 w-auto" />
         </Link>
-
-        {/* Десктопное меню */}
         <nav
           className={[
             "hidden md:flex items-center gap-8 text-sm transition-colors",
@@ -138,8 +135,6 @@ export default function Header() {
             Связаться
           </button>
         </nav>
-
-        {/* Бургер */}
         <button
           type="button"
           className={[
@@ -170,8 +165,6 @@ export default function Header() {
           )}
         </button>
       </div>
-
-      {/* Мобильное меню */}
       {open && (
         <div className="md:hidden absolute left-0 right-0 top-full z-50 bg-white shadow-lg border-t border-gray-200 animate-fadeIn">
           <ul className="flex flex-col divide-y divide-gray-200">

--- a/src/components/ui/Slider/Slider.tsx
+++ b/src/components/ui/Slider/Slider.tsx
@@ -12,9 +12,9 @@ export type Slide = {
   secondary?: { label: string; href: string };
   imageAlt?: string;
   background?: string;
-  imgMaxHMobile?: number;   // px
-  imgMaxHDesktop?: number;  // px
-  imgRightPx?: number;      // px (только для md+)
+  imgMaxHMobile?: number;
+  imgMaxHDesktop?: number;
+  imgRightPx?: number;
 };
 
 type Props = {
@@ -28,15 +28,12 @@ type Props = {
   showGlow?: boolean;
   glowColor?: string;
   glowSize?: number;
-  /** Картинка сверху на мобилке (sm и ниже) */
   mobileImageTop?: boolean;
-  /** Одинаковая высота карточек на мобилке, px (только для sm и ниже) */
   mobileSlideMinH?: number;
 
-  /** === Глобальные настройки размеров/смещения картинки === */
-  imageMaxHMobile?: number;   // px, по умолчанию 192 (≈ max-h-48)
-  imageMaxHDesktop?: number;  // px, по умолчанию 480
-  imageRightPx?: number;      // px, по умолчанию 112 (≈ right-28)
+  imageMaxHMobile?: number;
+  imageMaxHDesktop?: number;
+  imageRightPx?: number;
 };
 
 export default function Slider({
@@ -127,7 +124,7 @@ export default function Slider({
                     flex flex-col
                   "
                   style={{
-                    ["--mh" as any]: `${mobileSlideMinH}px`,
+                    ["--mh" as string]: `${mobileSlideMinH}px`,
                     background:
                       s.background ??
                       "linear-gradient(280.68deg, #054277 1.65%, #01192A 97.64%)",
@@ -150,7 +147,6 @@ export default function Slider({
                     />
                   )}
 
-                  {/* ====== Мобилка: картинка сверху, текст прибит к низу ====== */}
                   {mobileImageTop && s.image && (
                     <div className="md:hidden flex justify-center">
                       <img
@@ -163,7 +159,6 @@ export default function Slider({
                     </div>
                   )}
 
-                  {/* Блок текста на мобилке — в самом конце и с mt-auto */}
                   <div className="md:hidden mt-auto">
                     <div className="font-mono">
                       <h3 className="text-[24px] sm:text-[28px] font-bold leading-snug text-center">
@@ -191,7 +186,6 @@ export default function Slider({
                     </div>
                   </div>
 
-                  {/* ====== Планшет/Десктоп: сетка с картинкой справа ====== */}
                   <div
                     className="
                       hidden md:grid h-full relative
@@ -199,7 +193,6 @@ export default function Slider({
                       items-center
                     "
                   >
-                    {/* Текст слева */}
                     <div className="ml-0 md:ml-28 font-mono">
                       <h3 className="text-[32px] lg:text-[40px] font-bold leading-snug">
                         {s.title}
@@ -225,7 +218,6 @@ export default function Slider({
                       )}
                     </div>
 
-                    {/* Картинка справа */}
                     <div className="h-full">
                       <img
                         src={s.image}
@@ -245,7 +237,6 @@ export default function Slider({
                     </div>
                   </div>
 
-                  {/* Стрелки на md+ */}
                   <button
                     onClick={() => emblaApi?.scrollPrev()}
                     aria-label="Предыдущий слайд"


### PR DESCRIPTION
## Summary
- standardize section padding across components for consistent spacing
- remove leftover comments and clean up unused code
- replace any casts with proper types

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b756c30c208322b660b8f920c48d94