### PR TITLE
feat: add smooth scroll to contact form

### DIFF
--- a/src/app/index.css
+++ b/src/app/index.css
@@ -6,6 +6,7 @@
 *::after { box-sizing: border-box; }
 html, body, #root { min-height: 100%; overflow-x: hidden;}
 body { margin: 0; }
+html { scroll-behavior: smooth; }
 
 .overflow-x-auto::-webkit-scrollbar { height: 6px; }
 .overflow-x-auto::-webkit-scrollbar-track { background: transparent; }

--- a/src/components/Home/ReadySolutions/ReadySolutions.tsx
+++ b/src/components/Home/ReadySolutions/ReadySolutions.tsx
@@ -57,11 +57,13 @@ function SolutionModal({ open, onClose, solution }: ModalProps) {
         />
 
         <div className="p-6 flex justify-center ">
-          <a href={contactHref}>
-            <Button size="lg" className="rounded-full px-8 py-3 bg-emerald-400 text-black hover:bg-emerald-300 transition">
-              Связаться с нами
-            </Button>
-          </a>
+          <Button
+            size="lg"
+            className="rounded-full px-8 py-3 bg-emerald-400 text-black hover:bg-emerald-300 transition"
+            href={contactHref}
+          >
+            Связаться с нами
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/Home/TransformationCTA/TransformationCTA.tsx
+++ b/src/components/Home/TransformationCTA/TransformationCTA.tsx
@@ -14,9 +14,9 @@ export default function TransformationCTA() {
         </p>
 
         <div className="flex flex-wrap justify-center gap-4">
-          <a href="/check-lists/check-list_1.pdf" download>
-            <Button size="lg">Начать трансформацию</Button>
-          </a>
+          <Button size="lg" href="/check-lists/check-list_1.pdf" download>
+            Начать трансформацию
+          </Button>
         </div>
       </div>
     </section>

--- a/src/components/Services/ProductsSection/ProductsSection.tsx
+++ b/src/components/Services/ProductsSection/ProductsSection.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type ProductCard = {
   title: string;
   text: string;

--- a/src/components/Services/ServiceHero/ServiceHero.tsx
+++ b/src/components/Services/ServiceHero/ServiceHero.tsx
@@ -52,8 +52,8 @@ export default function ServiceHero({
         )}
 
         <div className="mt-8">
-          <Button size="lg" >
-            <a href={ctaHref}>{ctaLabel}</a>
+          <Button size="lg" href={ctaHref}>
+            {ctaLabel}
           </Button>
         </div>
       </div>

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,33 +1,65 @@
-import { forwardRef, type ButtonHTMLAttributes } from "react";
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type AnchorHTMLAttributes,
+  type ReactNode,
+} from "react";
 import "./button.css";
 import { BUTTON_SIZE_CLASS, BUTTON_SIZE_CLASS_SM, type ButtonSize } from "../../../app/data/button";
 
 type ButtonVariant = "solid" | "outline";
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+type ButtonOrAnchorProps =
+  | (ButtonHTMLAttributes<HTMLButtonElement> & { href?: undefined })
+  | (AnchorHTMLAttributes<HTMLAnchorElement> & { href: string });
+
+type ButtonProps = ButtonOrAnchorProps & {
   size?: ButtonSize;
   fullWidth?: boolean;
   variant?: ButtonVariant;
-}
+  className?: string;
+  children?: ReactNode;
+};
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+export const Button = forwardRef<
+  HTMLButtonElement | HTMLAnchorElement,
+  ButtonProps
+>(
   (
     {
-      size = "lg",            
+      size = "lg",
       fullWidth,
       variant = "solid",
       className = "",
       children,
-      ...props
+      ...rest
     },
     ref
   ) => {
     const width = fullWidth ? "btn--full" : "";
+    const classes = `btn btn--${variant} ${BUTTON_SIZE_CLASS["md"]} ${BUTTON_SIZE_CLASS_SM[size]} ${width} ${className}`;
+
+    if ("href" in rest && rest.href) {
+      const { href, ...anchorProps } = rest as AnchorHTMLAttributes<HTMLAnchorElement> & {
+        href: string;
+      };
+      return (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          className={classes}
+          {...anchorProps}
+        >
+          {children}
+        </a>
+      );
+    }
+
     return (
       <button
-        ref={ref}
-        className={`btn btn--${variant} ${BUTTON_SIZE_CLASS["md"]} ${BUTTON_SIZE_CLASS_SM[size]} ${width} ${className}`}
-        {...props}
+        ref={ref as React.Ref<HTMLButtonElement>}
+        className={classes}
+        {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
       >
         {children}
       </button>


### PR DESCRIPTION
## Summary
- allow Button to render as anchor via href
- enable smooth scrolling and link CTA buttons to the contact section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7df12c33c8322971c55572d8f19ec