### PR TITLE
docs: add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,58 @@
-# React + TypeScript + Vite
+# IT Source
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React, TypeScript and Vite project.
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js 20 or newer
+- npm
 
-## Expanding the ESLint configuration
+## Getting started
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+1. **Clone the repository**
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      ...tseslint.configs.recommendedTypeChecked,
-      ...tseslint.configs.strictTypeChecked,
-      ...tseslint.configs.stylisticTypeChecked,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
-])
-```
+   ```bash
+   git clone https://github.com/yourusername/IT-Source.git
+   cd IT-Source
+   ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+2. **Install dependencies**
 
-```js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+   ```bash
+   npm install
+   ```
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      reactX.configs['recommended-typescript'],
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
-])
-```
+3. **Configure environment variables**
+
+   The app reads the API base URL from `.env` files. For development you can use:
+
+   ```
+   VITE_API_BASE=/api
+   ```
+
+   Copy `.env.development` to `.env` and adjust if required.
+
+4. **Run in development mode**
+
+   ```bash
+   npm run dev
+   ```
+
+   The site will be available at [http://localhost:5173](http://localhost:5173).
+
+5. **Create a production build**
+
+   ```bash
+   npm run build
+   ```
+
+6. **Preview the production build**
+
+   ```bash
+   npm run preview
+   ```
+
+## Useful scripts
+
+- `npm run lint` – run ESLint to check the code.
+


### PR DESCRIPTION
## Summary
- add step-by-step instructions for setting up the project locally

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f4769bc8322b89f45460485d839