### PR TITLE
use root base path

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,7 +10,7 @@ export default function App() {
     <div className="bg-main min-h-screen font-mono">
       <Header />
       <Routes>
-        <Route path="/itsource/public/" element={<Home />} />
+        <Route path="/" element={<Home />} />
         <Route path="/services" element={<Services />} />
         <Route path="/tariffs" element={<Tariffs />} />
       </Routes>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,7 +18,7 @@ function scrollToId(id: string) {
 export default function Header() {
   const location = useLocation();
   const navigate = useNavigate();
-  const isHome = location.pathname === "/itsource/public/";
+  const isHome = location.pathname === "/";
   const [open, setOpen] = useState(false);
 
   const activeId = useMemo<SectionId | null>(() => {
@@ -34,7 +34,7 @@ export default function Header() {
   const goTo = (id: SectionId) => {
     switch (id) {
       case "home":
-        if (!isHome) navigate("/itsource/public/");
+        if (!isHome) navigate("/");
         else scrollToId("home");
         break;
       case "tariffs":

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: "/itsource/public/",
+  base: "/",
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
## Summary
- set Vite base path to `/`
- update home route and navigation for root path
- normalize header indentation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb43ae07ec8322a0895dd8efebee89